### PR TITLE
fix: Fix plant time recommendation date display

### DIFF
--- a/components/ui/date-display.tsx
+++ b/components/ui/date-display.tsx
@@ -54,6 +54,8 @@ export default function DateDisplay({ from, to }: DatePickerWithRangeProps) {
                     selected={date}
                     onSelect={() => {}}
                     numberOfMonths={1}
+                    fromDate={from}
+                    toDate={to}
                 />
             </div>
         </div>


### PR DESCRIPTION
Previously even dates outside the recommended dates were in focus. This fixes that.

| Before | After |
|:------:|:-----:|
| ![image](https://github.com/unpervertedkid/smart-farm-frontend/assets/71752651/ed85ffcd-26f7-4e33-863a-11dfb1fff6f6) | ![image](https://github.com/unpervertedkid/smart-farm-frontend/assets/71752651/f5d626f4-5f2f-4d7b-9a2d-3731057df37a) |